### PR TITLE
Add support for alternate display name format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.idea/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
+gem 'mocha'
+gem 'test-unit'
 gem 'addressable', '>= 2.3.2'
 gem 'faraday', '>= 0.9.0'
 gem 'multi_json', '>= 1.0.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.test_files = FileList['test/*_test.rb']
+end
+
+desc 'Run tests'
+task :default => :test

--- a/gitkit-ruby-client.gemspec
+++ b/gitkit-ruby-client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.description = 'Google Identity Toolkit Ruby client library'
   s.extra_rdoc_files = ["README.rdoc"]
   s.files = ["lib/gitkit_client.rb", "lib/rpc_helper.rb", "README.rdoc"]
+  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   if s.respond_to? :specification_version then
     s.specification_version = 4

--- a/lib/gitkit_client.rb
+++ b/lib/gitkit_client.rb
@@ -264,12 +264,10 @@ module GitkitLib
       user.email = api_response.fetch('email', nil)
       user.user_id = api_response.fetch('user_id',
           api_response.fetch('localId', nil))
-      user.name = api_response.fetch('displayName', nil)
-      user.photo_url = api_response.fetch('photoUrl', nil)
-      user.provider_id = api_response.fetch('provider_id',
-          api_response.fetch('providerId', nil))
-      user.email_verified = api_response.fetch('emailVerified',
-          api_response.fetch('verified', nil))
+      user.name = api_response.fetch('displayName', api_response.fetch('display_name', nil))
+      user.photo_url = api_response.fetch('photoUrl', api_response.fetch('photo_url', nil))
+      user.provider_id = api_response.fetch('provider_id', api_response.fetch('providerId', nil))
+      user.email_verified = api_response.fetch('emailVerified', api_response.fetch('verified', nil))
       user.password_hash = api_response.fetch('passwordHash', nil)
       user.salt = api_response.fetch('salt', nil)
       user.password = api_response.fetch('password', nil)

--- a/test/gitkit_client_test.rb
+++ b/test/gitkit_client_test.rb
@@ -4,6 +4,7 @@ require 'mocha/test_unit'
 require 'test/unit'
 require 'test_data'
 
+
 class GitkitClientTest < Test::Unit::TestCase
 
   def setup
@@ -52,10 +53,10 @@ class GitkitClientTest < Test::Unit::TestCase
 
   def test_download_account
     page1 = [
-        {'email' => 'email-1', 'localId' => 'user-1'},
-        {'email' => 'email-2', 'localId' => 'user-2'}]
+        {'email' => 'email-1', 'localId' => 'user-1', 'display_name' => 'name-1'},
+        {'email' => 'email-2', 'localId' => 'user-2', 'display_name' => 'name-2'}]
     page2 = [
-        {'email' => 'email-3', 'localId' => 'user-3'}]
+        {'email' => 'email-3', 'localId' => 'user-3', 'display_name' => 'name-3'}]
     stub = GitkitLib::RpcHelper.any_instance
     stub.expects(:download_account).with(nil, 2).returns(['page2_token', page1])
     stub.expects(:download_account).with('page2_token', 2).returns([nil, page2])
@@ -70,6 +71,7 @@ class GitkitClientTest < Test::Unit::TestCase
     gitkit_client.get_all_users(2) { |account|
       index = index + 1
       assert_equal 'user-' + index.to_s, account.user_id
+      assert_equal 'name-' + index.to_s, account.name
     }
     assert_equal 3, index
   end


### PR DESCRIPTION
I noticed the "name" attribute was not getting hydrated properly inside parse_from_api_response, so I added an additional check for the alternate "display_name".

I also added a Rakefile which makes it easier for users to run the tests: 

rake test