### PR TITLE
Support for missing params from the uploadAccount API

### DIFF
--- a/lib/gitkit_client.rb
+++ b/lib/gitkit_client.rb
@@ -139,10 +139,11 @@ module GitkitLib
     # @param [String] hash_algorithm password hash algorithm
     # @param [String] hash_key key of the hash algorithm
     # @param [Array<GitkitUser>] accounts user accounts to be uploaded
-    def upload_users(hash_algorithm, hash_key, accounts)
+    # @param [Hash] including options for saltSeparator, rounds, memoryCost
+    def upload_users(hash_algorithm, hash_key, accounts, other_params)
       account_request = accounts.collect { |account| account.to_request }
       @rpc_helper.upload_account hash_algorithm, JWT.base64url_encode(hash_key),
-          account_request
+          account_request, other_params
     end
 
     # Deletes a user account from Gitkit service

--- a/lib/gitkit_client.rb
+++ b/lib/gitkit_client.rb
@@ -140,7 +140,7 @@ module GitkitLib
     # @param [String] hash_key key of the hash algorithm
     # @param [Array<GitkitUser>] accounts user accounts to be uploaded
     # @param [Hash] including options for saltSeparator, rounds, memoryCost
-    def upload_users(hash_algorithm, hash_key, accounts, other_params)
+    def upload_users(hash_algorithm, hash_key, accounts, other_params = {})
       account_request = accounts.collect { |account| account.to_request }
       @rpc_helper.upload_account hash_algorithm, JWT.base64url_encode(hash_key),
           account_request, other_params

--- a/lib/rpc_helper.rb
+++ b/lib/rpc_helper.rb
@@ -100,12 +100,13 @@ module GitkitLib
     # @param <String> hash_algorithm hash algorithm
     # @param <String> hash_key hash key
     # @param <Array<GitkitUser>> accounts account to be uploaded
-    def upload_account(hash_algorithm, hash_key, accounts)
+    # @param [Hash] including options for hashAlgorithm, signerKey, saltSeparator, rounds, memoryCost
+    def upload_account(hash_algorithm, hash_key, accounts, other_params)
       param = {
           'hashAlgorithm' => hash_algorithm,
           'signerKey' => hash_key,
           'users' => accounts
-      }
+      }.merge(other_params)
       invoke_gitkit_api('uploadAccount', param)
     end
 

--- a/lib/rpc_helper.rb
+++ b/lib/rpc_helper.rb
@@ -101,7 +101,7 @@ module GitkitLib
     # @param <String> hash_key hash key
     # @param <Array<GitkitUser>> accounts account to be uploaded
     # @param [Hash] including options for hashAlgorithm, signerKey, saltSeparator, rounds, memoryCost
-    def upload_account(hash_algorithm, hash_key, accounts, other_params)
+    def upload_account(hash_algorithm, hash_key, accounts, other_params = {})
       param = {
           'hashAlgorithm' => hash_algorithm,
           'signerKey' => hash_key,


### PR DESCRIPTION
Uses a hash instead of named arguments, so that if need be we can freely pass any new request parameters added in future.

The params I needed to add support for my use case were

```
"saltSeparator": bytes,
"rounds": integer,
"memoryCost": integer
```
